### PR TITLE
GEN-213: adding support to duplicate keys in JSON for ObjectNodePubli…

### DIFF
--- a/src/main/java/io/openepcis/reactive/publisher/ObjectNodePublisher.java
+++ b/src/main/java/io/openepcis/reactive/publisher/ObjectNodePublisher.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
@@ -35,12 +36,15 @@ import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+
+import io.openepcis.reactive.publisher.util.JsonNodeDupeFieldHandlingDeserializer;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ObjectNodePublisher<T extends ObjectNode> implements Publisher<T> {
   private static final ObjectMapper mapper =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+      new ObjectMapper().registerModule(new JavaTimeModule())
+              .registerModule(new SimpleModule().addDeserializer(JsonNode.class, new JsonNodeDupeFieldHandlingDeserializer()));
   private static final JsonFactory jsonFactory = new JsonFactory();
   private final ObjectNode header = mapper.createObjectNode();
   private final JsonParser jsonParser;

--- a/src/main/java/io/openepcis/reactive/publisher/util/JsonNodeDupeFieldHandlingDeserializer.java
+++ b/src/main/java/io/openepcis/reactive/publisher/util/JsonNodeDupeFieldHandlingDeserializer.java
@@ -1,0 +1,46 @@
+package io.openepcis.reactive.publisher.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Custom class that extends "JsonNodeDeserializer" to read the JSON information with duplicate keys during the deserialization of the JSON EPCIS events.
+ */
+@JsonDeserialize(using = JsonNodeDupeFieldHandlingDeserializer.class)
+public class JsonNodeDupeFieldHandlingDeserializer extends JsonNodeDeserializer {
+
+    @Override
+    protected void _handleDuplicateField(
+            final JsonParser p,
+            final DeserializationContext context,
+            final JsonNodeFactory nodeFactory,
+            final String fieldName,
+            final ObjectNode objectNode,
+            final JsonNode oldValue,
+            final JsonNode newValue) {
+
+        // Prepare an ArrayNode to hold values associated with the duplicate field
+        ArrayNode asArrayValue;
+
+        // If the existing value is already an array, use it directly
+        if (oldValue.isArray()) {
+            asArrayValue = (ArrayNode) oldValue;
+        } else {
+            // Otherwise, create a new ArrayNode and add the existing value to it
+            asArrayValue = nodeFactory.arrayNode();
+            asArrayValue.add(oldValue);
+        }
+
+        // Add the new value to the array
+        asArrayValue.add(newValue);
+
+        // Replace the field in the ObjectNode with the updated array
+        objectNode.set(fieldName, asArrayValue);
+    }
+}


### PR DESCRIPTION
@sboeckelmann 

This PR will add support to our ObjectNodePublisher to handle the duplicate keys in user extensions within JSON without excluding those values.

Kindly request you to review the PR and approve the changes.